### PR TITLE
Fixed problem with responsive demo documentation

### DIFF
--- a/demo/md/responsive.md
+++ b/demo/md/responsive.md
@@ -4,4 +4,12 @@
   <Col xs={6} sm={6} md={8} lg={10} />
   <Col xs={6} sm={3} md={2} lg={1} />
 </Row>
+<Row>
+  <Col xs={12} sm={3} md={2} lg={1} />
+  <Col xs={12} sm={9} md={10} lg={11} />
+</Row>
+<Row>
+  <Col xs={10} sm={6} md={8} lg={10} />
+  <Col xs={2} sm={6} md={4} lg={2} />
+</Row>
 ```


### PR DESCRIPTION
The responsive demo docs list only one row, but the demo shows three. Updated markdown to show all three rows. 