### PR TITLE
Added prop-types package

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,13 +77,11 @@
     "rollup-plugin-visualizer": "^0.2.0",
     "webpack": "^2.2.1",
     "webpack-dev-server": "^2.4.2",
-    "webpack-hot-middleware": "^2.17.1"
+    "webpack-hot-middleware": "^2.17.1",
+    "prop-types": "^15.5.8"
   },
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0-0",
     "styled-components": "^1.3.1 || ^2.0.0-1"
-  },
-  "dependencies": {
-    "prop-types": "^15.5.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -82,5 +82,8 @@
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0-0",
     "styled-components": "^1.3.1 || ^2.0.0-1"
+  },
+  "dependencies": {
+    "prop-types": "^15.5.8"
   }
 }

--- a/src/components/Col.js
+++ b/src/components/Col.js
@@ -1,5 +1,6 @@
 
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import styled from 'styled-components'
 
 import createProps from '../createProps'

--- a/src/components/Grid.js
+++ b/src/components/Grid.js
@@ -1,5 +1,6 @@
 
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import styled, { css } from 'styled-components'
 
 import createProps from '../createProps'

--- a/src/components/Row.js
+++ b/src/components/Row.js
@@ -1,5 +1,6 @@
 
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import styled from 'styled-components'
 
 import createProps from '../createProps'


### PR DESCRIPTION
This will remove the deprecated warning:

`Warning: Accessing PropTypes via the main React package is deprecated. Use the prop-types package from npm instead.`