### PR TITLE
Fixed prop-types deprecated React v15.5.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 dist
 lib
 bundle-stats.html
+*.log

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ npm i -S react-styled-flexboxgrid
 
 `react-styled-flexboxgrid` depends on 2 **peer** dependencies:
 - `react@^0.14.0 || ^15.0.0-0`
+- `prop-types@^15.0.0-0`
 - `styled-components@^1.3.1`
 
 You should install them in your project.

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
   },
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0-0",
+    "prop-types": "^15.0.0-0",
     "styled-components": "^1.3.1 || ^2.0.0-1"
   }
 }

--- a/src/components/Col.js
+++ b/src/components/Col.js
@@ -1,5 +1,6 @@
 
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import styled from 'styled-components'
 
 import createProps from '../createProps'

--- a/src/components/Grid.js
+++ b/src/components/Grid.js
@@ -1,5 +1,6 @@
 
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import styled, { css } from 'styled-components'
 
 import createProps from '../createProps'

--- a/src/components/Row.js
+++ b/src/components/Row.js
@@ -1,5 +1,6 @@
 
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import styled from 'styled-components'
 
 import createProps from '../createProps'


### PR DESCRIPTION
Fixed prop-types deprecated React v15.5.4

| Dependency      | prop-types       |
|-----------------|------------------|

| Current Version | 15.5.7           |
|-----------------|------------------|

| Type            | peerDependencies |
|-----------------|------------------|

Fix issue [https://github.com/LoicMahieu/react-styled-flexboxgrid/issues/32](url)