### PR TITLE
Fix IE<=11 compatibility due to missing of `Number.isInteger`

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,5 +87,8 @@
     "react": "^0.14.0 || ^15.0.0-0",
     "prop-types": "^15.0.0-0",
     "styled-components": "^2.0.0"
+  },
+  "dependencies": {
+    "lodash.isinteger": "^4.0.4"
   }
 }

--- a/src/components/Col.js
+++ b/src/components/Col.js
@@ -1,6 +1,7 @@
 
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
+import isInteger from 'lodash.isinteger'
 
 import config, { DIMENSION_NAMES } from '../config'
 
@@ -27,7 +28,7 @@ const Col = styled.div`
     .filter(k => ~DIMENSION_NAMES.indexOf(k))
     .sort(k => DIMENSION_NAMES.indexOf(k))
     .map(k => config(p).media[k]`${
-      Number.isInteger(p[k])
+      isInteger(p[k])
 
       // Integer value
       ? `


### PR DESCRIPTION
Replaced by `lodash.isinteger`

Fix #50