### PR TITLE
Modify default lg value to prevent overflow/scroll

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -10,7 +10,7 @@ export const BASE_CONF = {
   container: {
     sm: 46,
     md: 61,
-    lg: 76
+    lg: 72
   },
   breakpoints: {
     xs: 0,


### PR DESCRIPTION
The previous value caused overflow on screens of size >75rem as the lg container size was 76 and breakpoint 75.